### PR TITLE
Fixing initial opposite direction

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -43,8 +43,8 @@ function createGame(fps$: Observable<number>): Observable<Scene> {
   let direction$ = keydown$
     .map((event: KeyboardEvent) => DIRECTIONS[event.keyCode])
     .filter(direction => !!direction)
-    .scan(nextDirection)
     .startWith(INITIAL_DIRECTION)
+    .scan(nextDirection)
     .distinctUntilChanged();
 
   let length$ = new BehaviorSubject<number>(SNAKE_LENGTH);


### PR DESCRIPTION
When the game is starting the detection of opposite directions is not working, because `.startWith(INITIAL_DIRECTION)` is after `.scan(nextDirection)`, so `nextDirection` is not called on first keydown.